### PR TITLE
Silicons can now open doors. (NON MODULAR BUT IT DOESNT MATTER ANYMORE WE ARE DIVERGING)

### DIFF
--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -8,9 +8,10 @@
 		if(ispAI(M))
 			return FALSE
 		// return TRUE	//AI can do whatever it wants
-		if (check_ship_ai_access(M))
+		//if (check_ship_ai_access(M))
 			// No, AI can't do whatever it wants anymore :)
-			return TRUE
+		//>:( Fuck you. It can do what it wants!!! *raspberry*
+		return TRUE
 	if(isAdminGhostAI(M))
 		//Access can't stop the abuse
 		return TRUE
@@ -123,6 +124,7 @@
 
 	return FALSE
 
+//TODO: actually fix this, it doesn't work.
 /obj/proc/check_ship_ai_access(mob/living/silicon/robot)
 	var/datum/overmap/ship/controlled/ship = SSshuttle.get_ship(src)
 	if (gen_ship_access(ship))


### PR DESCRIPTION
This is a very much needed quality of life update for AIs and borgs.

This was done because AIs and borgs made on a ship would not have access to the ship. That is a disgrace.

Also, borgs and AIs can open any door anywhere. Should not matter due to the small size of the server.


