### PR TITLE
Wing reconstruction

### DIFF
--- a/code/modules/surgery/wing_reconstruction.dm
+++ b/code/modules/surgery/wing_reconstruction.dm
@@ -10,7 +10,8 @@
 /datum/surgery/wing_reconstruction/can_start(mob/user, mob/living/carbon/target)
 	/*
 	Condition - Target has moth_wings loaded to dna.species.mutant_bodyparts
-		Note: Whatever wing variation the target had prior to the burning was overwrote by "Burnt Off" (Which is a variation of wings it seems)
+		Note 1: This should also work on subjects who have had moth wings inserted into their body via "organ manipulation" surgery
+		Note 2: Whatever wing variation the target had prior to the surgery will be overwrote. To include "Burned Off" which is its own variation
 	*/
 	if("moth_wings" in target.dna.species.mutant_bodyparts)
 		return TRUE //Yes surgery
@@ -49,11 +50,12 @@
 		Condition 1 - List of wing types for new wings
 		Condition 2 - Sets moth_wings to wing_type. This overrides previous wing variation - Including "Burnt Off"
 		Condition 3 - Update target body
+
+		Warning: Do not run on 515.1636 - Disconnecting while the input is up causes surgery lockout on chest. Requires VV editing to fix
 		*/
-		var/wing_type = input("Choose a new wing look:", "Wing Reconstruction") as anything in GLOB.moth_wings_list
-		/*
-		Warning: Still need to find a solution for if an input doesnt happen... never finish's the surgery and cant end it in other ways...
-		*/
+		var/wing_type = input("Choose a new wing look:", "Wing Reconstruction") as null|anything in GLOB.moth_wings_list
+		if(!wing_type)
+			return
 		target.dna.features["moth_wings"] = wing_type
 		target.update_body()
 		display_results(

--- a/code/modules/surgery/wing_reconstruction.dm
+++ b/code/modules/surgery/wing_reconstruction.dm
@@ -23,7 +23,7 @@
 		TOOL_HEMOSTAT = 85,
 		TOOL_SCREWDRIVER = 35,
 		/obj/item/pen = 15)
-	time = 20 SECONDS
+	time = 10 SECONDS
 	preop_sound = 'sound/surgery/scalpel1.ogg'
 	success_sound = 'sound/surgery/scalpel2.ogg'
 	failure_sound = 'sound/surgery/organ2.ogg'
@@ -42,10 +42,9 @@
 		display_results(
 			user,
 			target,
-			span_notice("You succeed in reconstructing [target]'s wings."),
-			span_notice("[user] successfully reconstructs [target]'s wings!"),
-			span_notice("[user] completes the surgery on [target]'s wings."),
-		)
+			"<span class='notice'>You succeed in reconstructing [target]'s wings...</span>",
+			"<span class='notice'>[user] successfully reconstructs [target]'s wings!",
+			"<span class='notice'>[user] completes the surgery on [target]'s wings.",)
 		/*
 		Condition 1 - List of wing types for new wings
 		Condition 2 - Sets moth_wings to wing_type. This overrides previous wing variation - Including "Burnt Off"

--- a/code/modules/surgery/wing_reconstruction.dm
+++ b/code/modules/surgery/wing_reconstruction.dm
@@ -4,7 +4,7 @@
 		/datum/surgery_step/incise,
 		/datum/surgery_step/retract_skin,
 		/datum/surgery_step/clamp_bleeders,
-		/datum/surgery_step/wing_reconstruction,
+		/datum/surgery_step/wing_reconstruction,)
 	possible_locs = list(BODY_ZONE_CHEST)
 
 /datum/surgery/wing_reconstruction/can_start(mob/user, mob/living/carbon/target)
@@ -51,9 +51,12 @@
 		Condition 2 - Sets moth_wings to wing_type. This overrides previous wing variation - Including "Burnt Off"
 		Condition 3 - Update target body
 		*/
-        var/wing_type = input("Choose a new wing look:", "Wing Reconstruction") as anything in GLOB.moth_wings_list
-        target.dna.features["moth_wings"] = wing_type
-        target.update_body()
+		var/wing_type = input("Choose a new wing look:", "Wing Reconstruction") as anything in GLOB.moth_wings_list
+		/*
+		Warning: Still need to find a solution for if an input doesnt happen... never finish's the surgery and cant end it in other ways...
+		*/
+		target.dna.features["moth_wings"] = wing_type
+		target.update_body()
 		display_results(
 			user,
 			target,
@@ -61,12 +64,3 @@
 			"<span class='notice'>[user] alters [target]'s winga completely, [target] now has [wing_type] wings!</span>",
 			"<span class='notice'>[user] finishes the operation on [target]'s wings.</span>")
 	return ..()
-
-	/datum/surgery_step/wing_reconstruction/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	display_results(
-		user,
-		target,
-		"<span class='warning'>You screw up, leaving [target]'s appearance the same!</span>",
-		"<span class='notice'>[user] screws up, luckily [target]'s appearance did not change!</span>",
-		"<span class='notice'>[user] finishes the operation on [target]'s wings.</span>")
-	return FALSE

--- a/code/modules/surgery/wing_reconstruction.dm
+++ b/code/modules/surgery/wing_reconstruction.dm
@@ -61,7 +61,7 @@
 		display_results(
 			user,
 			target,
-			"<span class='notice'>You alter [target]'s wings completely, [target] is has [wing_type] wings.</span>",
+			"<span class='notice'>You alter [target]'s wings completely, [target] now has [wing_type] wings.</span>",
 			"<span class='notice'>[user] alters [target]'s winga completely, [target] now has [wing_type] wings!</span>",
 			"<span class='notice'>[user] finishes the operation on [target]'s wings.</span>")
 	return ..()

--- a/code/modules/surgery/wing_reconstruction.dm
+++ b/code/modules/surgery/wing_reconstruction.dm
@@ -5,7 +5,6 @@
 		/datum/surgery_step/retract_skin,
 		/datum/surgery_step/clamp_bleeders,
 		/datum/surgery_step/wing_reconstruction,
-		/datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_CHEST)
 
 /datum/surgery/wing_reconstruction/can_start(mob/user, mob/living/carbon/target)
@@ -52,11 +51,22 @@
 		Condition 2 - Sets moth_wings to wing_type. This overrides previous wing variation - Including "Burnt Off"
 		Condition 3 - Update target body
 		*/
-		var/wing_type = input( "Choose a new wing look:", "Wing Reconstruction") as anything in GLOB.moth_wings_list
-		//if(wing_type == 22)
-		//	target.dna.features["moth_wings"] = "Plain"
-		//	target.update_body()
-		//	return ..()
-		target.dna.features["moth_wings"] = wing_type
-		target.update_body()
+        var/wing_type = input("Choose a new wing look:", "Wing Reconstruction") as anything in GLOB.moth_wings_list
+        target.dna.features["moth_wings"] = wing_type
+        target.update_body()
+		display_results(
+			user,
+			target,
+			"<span class='notice'>You alter [target]'s wings completely, [target] is has [wing_type] wings.</span>",
+			"<span class='notice'>[user] alters [target]'s winga completely, [target] now has [wing_type] wings!</span>",
+			"<span class='notice'>[user] finishes the operation on [target]'s wings.</span>")
 	return ..()
+
+	/datum/surgery_step/wing_reconstruction/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(
+		user,
+		target,
+		"<span class='warning'>You screw up, leaving [target]'s appearance the same!</span>",
+		"<span class='notice'>[user] screws up, luckily [target]'s appearance did not change!</span>",
+		"<span class='notice'>[user] finishes the operation on [target]'s wings.</span>")
+	return FALSE

--- a/code/modules/surgery/wing_reconstruction.dm
+++ b/code/modules/surgery/wing_reconstruction.dm
@@ -1,27 +1,21 @@
 /datum/surgery/wing_reconstruction
-	name = "Wing Reconstruction v1"
+	name = "Wing Reconstruction"
 	steps = list(
 		/datum/surgery_step/incise,
 		/datum/surgery_step/retract_skin,
 		/datum/surgery_step/clamp_bleeders,
-		/datum/surgery_step/wing_reconstruction)
+		/datum/surgery_step/wing_reconstruction,
+		/datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_CHEST)
 
 /datum/surgery/wing_reconstruction/can_start(mob/user, mob/living/carbon/target)
 	/*
-	Condition 1 - Target has moth_wings loaded to dna.species.mutant_bodyparts
-	Condition 2 - Target has moth_wings set to "Burnt Off" wing variation -
+	Condition - Target has moth_wings loaded to dna.species.mutant_bodyparts
 		Note: Whatever wing variation the target had prior to the burning was overwrote by "Burnt Off" (Which is a variation of wings it seems)
 	*/
-	if("moth_wings" in target.dna.species.mutant_bodyparts && H.dna.features["moth_wings"] = "Burnt Off")
+	if("moth_wings" in target.dna.species.mutant_bodyparts)
 		return TRUE //Yes surgery
 	return FALSE //No surgery
-	/*
-	Version 1
-		if(!("moth_wings" in target.dna.species.mutant_bodyparts)) //if they don't have wings, dont do surgery
-		return FALSE
-	return TRUE
-	*/
 
 /datum/surgery_step/wing_reconstruction
 	name = "start wing reconstruction (hemostat)"
@@ -54,11 +48,15 @@
 			span_notice("[user] completes the surgery on [target]'s wings."),
 		)
 		/*
-		Condition 1 - Set wing_type to Plain (Yellow)
-		Condition 2 - Sets moth_wings to wing_type. This overrides "Burnt Off" wing variation
+		Condition 1 - List of wing types for new wings
+		Condition 2 - Sets moth_wings to wing_type. This overrides previous wing variation - Including "Burnt Off"
 		Condition 3 - Update target body
 		*/
-		var/wing_type = "Plain"
+		var/wing_type = input( "Choose a new wing look:", "Wing Reconstruction") as anything in GLOB.moth_wings_list
+		//if(wing_type == 22)
+		//	target.dna.features["moth_wings"] = "Plain"
+		//	target.update_body()
+		//	return ..()
 		target.dna.features["moth_wings"] = wing_type
 		target.update_body()
 	return ..()

--- a/code/modules/surgery/wing_reconstruction.dm
+++ b/code/modules/surgery/wing_reconstruction.dm
@@ -1,0 +1,64 @@
+/datum/surgery/wing_reconstruction
+	name = "Wing Reconstruction v1"
+	steps = list(
+		/datum/surgery_step/incise,
+		/datum/surgery_step/retract_skin,
+		/datum/surgery_step/clamp_bleeders,
+		/datum/surgery_step/wing_reconstruction)
+	possible_locs = list(BODY_ZONE_CHEST)
+
+/datum/surgery/wing_reconstruction/can_start(mob/user, mob/living/carbon/target)
+	/*
+	Condition 1 - Target has moth_wings loaded to dna.species.mutant_bodyparts
+	Condition 2 - Target has moth_wings set to "Burnt Off" wing variation -
+		Note: Whatever wing variation the target had prior to the burning was overwrote by "Burnt Off" (Which is a variation of wings it seems)
+	*/
+	if("moth_wings" in target.dna.species.mutant_bodyparts && H.dna.features["moth_wings"] = "Burnt Off")
+		return TRUE //Yes surgery
+	return FALSE //No surgery
+	/*
+	Version 1
+		if(!("moth_wings" in target.dna.species.mutant_bodyparts)) //if they don't have wings, dont do surgery
+		return FALSE
+	return TRUE
+	*/
+
+/datum/surgery_step/wing_reconstruction
+	name = "start wing reconstruction (hemostat)"
+	//success chance per tool
+	implements = list(
+		TOOL_HEMOSTAT = 85,
+		TOOL_SCREWDRIVER = 35,
+		/obj/item/pen = 15)
+	time = 20 SECONDS
+	preop_sound = 'sound/surgery/scalpel1.ogg'
+	success_sound = 'sound/surgery/scalpel2.ogg'
+	failure_sound = 'sound/surgery/organ2.ogg'
+	experience_given = MEDICAL_SKILL_ORGAN_FIX
+
+/datum/surgery_step/wing_reconstruction/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(
+		user,
+		target,
+		"<span class='notice'>You begin to fix [target]'s charred wing membranes...</span>",
+		"<span class='notice'>[user] begins to fix [target]'s charred wing membranes.</span>",
+		"<span class='notice'>[user] begins to perform surgery on [target]'s charred wing membranes.</span>")
+
+/datum/surgery_step/wing_reconstruction/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, default_display_results = FALSE)
+	if(ishuman(target))
+		display_results(
+			user,
+			target,
+			span_notice("You succeed in reconstructing [target]'s wings."),
+			span_notice("[user] successfully reconstructs [target]'s wings!"),
+			span_notice("[user] completes the surgery on [target]'s wings."),
+		)
+		/*
+		Condition 1 - Set wing_type to Plain (Yellow)
+		Condition 2 - Sets moth_wings to wing_type. This overrides "Burnt Off" wing variation
+		Condition 3 - Update target body
+		*/
+		var/wing_type = "Plain"
+		target.dna.features["moth_wings"] = wing_type
+		target.update_body()
+	return ..()

--- a/shiptest.dme
+++ b/shiptest.dme
@@ -3371,6 +3371,7 @@
 #include "code\modules\surgery\surgery_helpers.dm"
 #include "code\modules\surgery\surgery_step.dm"
 #include "code\modules\surgery\tools.dm"
+#include "code\modules\surgery\wing_reconstruction.dm"
 #include "code\modules\surgery\advanced\brainwashing.dm"
 #include "code\modules\surgery\advanced\lobotomy.dm"
 #include "code\modules\surgery\advanced\necrotic_revival.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Added: Wing Reconstruction Surgery for creatures with Moth Wings.

## Why It's Good For The Game

Currently once Moth Wings are set to the "Burned Off" state there is no way to correct this. Even if the organ, located inside the chest, is removed and replaced the subjects DNA value which determines which variation of wings they have stays as "Burned Off"

This allows for a person with Moth Wings to have their wings restored. Yet, due to the fact that their previous style gets overwrote by "Burned Off" this also acts as a plastic surgery for wings, allowing them to be changed.

## Changelog

:cl:
add: Wing Reconstruction
del: Debug Text
code: Cleaned up span code
server: Can cause surgery lockout on chest in ver 515.1636
code: Cleaned up Grammar in final span text
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->